### PR TITLE
Add gitattributes w/ export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Ignore un-needed files and directories for export of production releases
+# Keeps dist/
+#
+# See: http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository
+
+.gitattributes export-ignore
+.gitignore export-ignore
+bower.json export-ignore
+Gulpfile.js export-ignore
+package.json export-ignore
+scrollReveal.js

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,5 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
-bower.json export-ignore
 Gulpfile.js export-ignore
-package.json export-ignore
 scrollReveal.js


### PR DESCRIPTION
This will allow for a production ready version of `scrollReveal` when archived/exported for release(s) and still allowing a development version within the repository.

This would be very useful because releases are intended for production use and when users are using a packaged release (e.g. as a dependency), they most likely are not interested in downloading the source code as a whole into production, thus saving server disk space and meeting security protocol. Think of it as a .gitignore for releases.

  - e.g. /test folders, or other build code etc., will not be included in the release archives (zip & tar.gz)

See: [git-scm.com - Exporting-Your-Repository](http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Exporting-Your-Repository)