### PR TITLE
Fix for mobile browsers

### DIFF
--- a/dist/scrollreveal.js
+++ b/dist/scrollreveal.js
@@ -165,13 +165,13 @@ ______________________________________________________________________________*/
       elem.styles.transition.delayed = '-webkit-transition: ' + elem.styles.computed.transition + '-webkit-transform ' + config.duration / 1000 + 's ' + config.easing + ' ' + config.delay / 1000 + 's, opacity ' + config.duration / 1000 + 's ' + config.easing + ' ' + config.delay / 1000 + 's; ' +
                                                'transition: ' + elem.styles.computed.transition + 'transform ' + config.duration / 1000 + 's ' + config.easing + ' ' + config.delay / 1000 + 's, opacity ' + config.duration / 1000 + 's ' + config.easing + ' ' + config.delay / 1000 + 's; ';
 
-      elem.styles.transform.initial += ' -webkit-transform:';
-      elem.styles.transform.target  += ' -webkit-transform:';
-      generateTransform( elem.styles.transform );
-
       elem.styles.transform.initial = 'transform:';
       elem.styles.transform.target  = 'transform:';
       generateTransform( elem.styles.transform );
+
+      elem.styles.transform.initial += ' -webkit-transform:';
+      elem.styles.transform.target  += ' -webkit-transform:';
+      generateTransform( elem.styles.transform );      
 
       function generateTransform( transform ) {
         if ( parseInt( config.distance ) ) {


### PR DESCRIPTION
Adding the prefix "-webkit-" in correct order. Working smooth in ipad/ios/Chrome and safari; Android5/Chrome.