### PR TITLE
Fix selector with config.container in Instantiation [fix #289]

### DIFF
--- a/dist/scrollreveal.js
+++ b/dist/scrollreveal.js
@@ -282,8 +282,7 @@
   function _resolveContainer (config) {
     if (config && config.container) {
       if (typeof config.container === 'string') {
-        sr.defaults.container = window.document.documentElement.querySelector(config.container)
-        return sr.defaults.container
+        return window.document.documentElement.querySelector(config.container)
       } else if (sr.tools.isNode(config.container)) {
         return config.container
       } else {

--- a/dist/scrollreveal.js
+++ b/dist/scrollreveal.js
@@ -282,7 +282,8 @@
   function _resolveContainer (config) {
     if (config && config.container) {
       if (typeof config.container === 'string') {
-        return window.document.documentElement.querySelector(config.container)
+        sr.defaults.container = window.document.documentElement.querySelector(config.container)
+        return sr.defaults.container
       } else if (sr.tools.isNode(config.container)) {
         return config.container
       } else {

--- a/dist/scrollreveal.js
+++ b/dist/scrollreveal.js
@@ -41,7 +41,7 @@
     if (sr.isSupported()) {
       sr.tools.extend(sr.defaults, config || {})
 
-      _resolveContainer(sr.defaults)
+      sr.defaults.container = _resolveContainer(sr.defaults)
 
       sr.store = {
         elements: {},


### PR DESCRIPTION
Save container as Node object when the config input is string 